### PR TITLE
Add Google Analytics as a Gatsby plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ I have a strong interest in building products that people love. Products that ar
 
 You can follow me on [Twitter](http://twitter.com/amorriscode) or take a look at my career path on [LinkedIn](https://www.linkedin.com/in/amorriscode).
 
-This website was built using [Gatsby](https://gatsbyjs.org) with deployments covered by [Netlify](https://www.netlify.com).
+This website was built using [Gatsby](https://gatsbyjs.org) with deployments covered by [now](https://zeit.co/now).

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -27,6 +27,13 @@ module.exports = {
         icon: `src/images/rocket-icon.png`, // This path is relative to the root of the site.
       },
     },
+    {
+      resolve: `gatsby-plugin-google-analytics`,
+      options: {
+        trackingId: "UA-143384618-2",
+        cookieDomain: "anthonymorris.dev",
+      },
+    }
     // this (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.dev/offline
     // `gatsby-plugin-offline`,

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "gatsby": "^2.13.4",
     "gatsby-image": "^2.2.4",
+    "gatsby-plugin-google-analytics": "^2.1.4",
     "gatsby-plugin-manifest": "^2.2.1",
     "gatsby-plugin-offline": "^2.2.1",
     "gatsby-plugin-react-helmet": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4952,6 +4952,13 @@ gatsby-page-utils@^0.0.2:
     micromatch "^3.1.10"
     slash "^1.0.0"
 
+gatsby-plugin-google-analytics@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-2.1.4.tgz#f0b64900e125cef03e930332c45063ece8263206"
+  integrity sha512-TyCazAUVMfMy6U/dHtXYLg9FTS7PtOBrRZkpp0Pdqe2M9qA10xG54JZpjJcLGUkZr5oeZPjNAvoiVyatrTcWiw==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
 gatsby-plugin-manifest@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.2.1.tgz#89d23587bfddbf3ce606fc353555d372cfc7d432"


### PR DESCRIPTION
Because I've moved the project to [now](https://zeit.co/now), I can't use the lovely Netlify GA tool. This PR adds the `gatsby-plugin-google-analytics` plugin so I can still get those sweet analytics.